### PR TITLE
specify reset_histograms=false while fetching metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This is how hostnames or ip addresses are specified:
 ```
 ./target/release/yb_stats --hosts 192.168.66.80,192.168.66.81,192.168.66.82
 ```
-yb_stats will collect statistics from the ports 7000, 9000, 12000, 13000 and 9300 by default. If this list needs to be changed, you can specify the required ports list using the `-p` or `--ports` switch, for example:
+yb_stats will collect statistics from the ports 7000, 9000, 12000 and 13000 by default. Node exporter -- 9300 is not included by default. If this list needs to be changed, you can specify the required ports list using the `-p` or `--ports` switch, for example:
 ```
 ./target/release/yb_stats --ports 9000,13001
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ mod drives;
 
 // constants
 const DEFAULT_HOSTS: &str = "192.168.66.80,192.168.66.81,192.168.66.82";
-const DEFAULT_PORTS: &str = "7000,9000,12000,13000,9300";
+const DEFAULT_PORTS: &str = "7000,9000,12000,13000";
 const DEFAULT_PARALLEL: &str = "1";
 /// Write the `.env` in the current working directory?
 const WRITE_DOTENV: bool = true;

--- a/src/metrics/functions.rs
+++ b/src/metrics/functions.rs
@@ -75,7 +75,7 @@ impl AllMetricEntity {
         port: &str,
     ) -> Vec<MetricEntity>
     {
-        let data_from_http = utility::http_get(host, port, "metrics");
+        let data_from_http = utility::http_get(host, port, "metrics?reset_histograms=false");
         AllMetricEntity::parse_metrics(data_from_http, host, port)
     }
     fn parse_metrics(

--- a/src/node_exporter/functions.rs
+++ b/src/node_exporter/functions.rs
@@ -75,7 +75,7 @@ impl AllNodeExporter {
         port: &str,
     ) -> Vec<NodeExporter>
     {
-        let data_from_http = utility::http_get(host, port, "metrics");
+        let data_from_http = utility::http_get(host, port, "metrics?reset_histograms=false");
         AllNodeExporter::parse_nodeexporter(data_from_http)
     }
     fn parse_nodeexporter( 


### PR DESCRIPTION
We (yb-tserver/yb-master) have certain metrics (Histograms) that track the mean/min/max/p95s etc. These are supposed to be collected/figured out over a specific time interval.

So, each time the node_exporter/prometheus pulls the data from /metrics or /prometheus-metrics; it will reset these histograms; so the min/max etc correspond to the min/max over the 10s interval/frequency when the script runs.
When we manually look at the metrics etc, we generally try to avoid resetting the histograms, and so the url on the /utilz page actually points to something like
"http://$0/prometheus-metrics?reset_histograms=false&show_help=true"

Would be preferrable if yb_stats does the same; since the default value for reset_histogram is set to true. Not a big deal, but the tldr is that p95/p99 metrics may be perturbed if we run scripts that pull/trigger the histograms to reset.

Tested with the following (local) change got yugabyte:
```
commit 66f63d4ebffed6df1a70a66aee1e2405257ed6f6 (HEAD -> cache_test)
Author: Amitanand Aiyer <amitanandaiyer@users.noreply.github.com>
Date:   Fri Oct 4 16:34:29 2024 +0800

    reset histograms

diff --git a/src/yb/server/default-path-handlers.cc b/src/yb/server/default-path-handlers.cc
index 59263dbe1d..234fc32760 100644
--- a/src/yb/server/default-path-handlers.cc
+++ b/src/yb/server/default-path-handlers.cc
@@ -606,6 +606,7 @@ void ParseRequestOptions(

     string arg = FindWithDefault(req.parsed_args, "reset_histograms", "true");
     metric_opts->reset_histograms = ParseLeadingBoolValue(arg.c_str(), true);
+    LOG(INFO) << __func__ << " reset_histograms: " << metric_opts->reset_histograms;

     arg = FindWithDefault(req.parsed_args, "level", "debug");
     SetParsedValue(&metric_opts->level, MetricLevelFromName(arg));
```

Logs before, during yb_stats 
```
I1004 08:47:11.817708 3281496 default-path-handlers.cc:609] operator() reset_histograms: 1
I1004 08:47:11.824481 3281495 default-path-handlers.cc:609] operator() reset_histograms: 1
```

Logs after:
```
I1004 08:56:13.438763 3282358 default-path-handlers.cc:609] operator() reset_histograms: 0
I1004 08:56:13.439425 3282359 default-path-handlers.cc:609] operator() reset_histograms: 0
```
